### PR TITLE
Add Python SDK wrapper

### DIFF
--- a/codex_python/README.md
+++ b/codex_python/README.md
@@ -1,0 +1,14 @@
+# Codex Python SDK
+
+This is a minimal Python wrapper for the `codex` command line tool.
+It allows running Codex in *full‑auto* mode from Python scripts.
+
+```
+from codex_python import run_codex
+
+result = run_codex("create a new file", working_dir="/path/to/repo")
+print(result.stdout)
+```
+
+The SDK simply spawns the `codex` binary. Ensure the CLI is installed
+and available on your `$PATH`.

--- a/codex_python/__init__.py
+++ b/codex_python/__init__.py
@@ -1,0 +1,60 @@
+"""Minimal Python SDK for the Codex CLI.
+
+This module provides a small wrapper around the ``codex`` command
+line tool. It allows running Codex in full-auto mode and capturing the
+output programmatically.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence
+
+__all__ = ["CodexCLI", "run_codex"]
+
+
+class CodexCLI:
+    """Thin wrapper around the ``codex`` command line interface."""
+
+    def __init__(
+        self,
+        codex_bin: str = "codex",
+        working_dir: Optional[Path] = None,
+        approval_mode: str = "full-auto",
+        full_auto_error_mode: str | None = None,
+        extra_args: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.codex_bin = codex_bin
+        self.working_dir = Path(working_dir) if working_dir else None
+        self.approval_mode = approval_mode
+        self.full_auto_error_mode = full_auto_error_mode
+        self.extra_args = list(extra_args) if extra_args else []
+
+    def run(self, prompt: str, *args: str) -> subprocess.CompletedProcess:
+        """Run Codex with the given prompt.
+
+        Any additional ``args`` are appended to the command.
+        The process output is returned via ``subprocess.CompletedProcess``.
+        """
+        cmd: list[str] = [self.codex_bin]
+        if self.approval_mode:
+            cmd += ["--approval-mode", self.approval_mode]
+        if self.full_auto_error_mode:
+            cmd += ["--full-auto-error-mode", self.full_auto_error_mode]
+        cmd += self.extra_args
+        cmd += list(args)
+        cmd.append(prompt)
+
+        return subprocess.run(
+            cmd,
+            cwd=self.working_dir,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+
+def run_codex(prompt: str, *args: str, **kwargs) -> subprocess.CompletedProcess:
+    """Convenience function to run Codex in full-auto mode."""
+    cli = CodexCLI(**kwargs)
+    return cli.run(prompt, *args)


### PR DESCRIPTION
## Summary
- introduce `codex_python` package
- add simple `CodexCLI` wrapper to run in full-auto mode

## Testing
- `python3 --version`
- `python3 -m pip --version`


------
https://chatgpt.com/codex/tasks/task_b_683a70112c98832699d19c992b07a36b